### PR TITLE
Updated to Scala 2.12, Spark 3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,9 +66,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <scala.version>2.11.12</scala.version>
-        <scala.binary.version>2.11</scala.binary.version>
-        <spark.version>2.4.4</spark.version>
+        <scala.version>2.12.8</scala.version>
+        <scala.binary.version>2.12</scala.binary.version>
+        <spark.version>3.0.1</spark.version>
         <java.version>1.8</java.version>
     </properties>
 
@@ -84,6 +84,12 @@
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-reflect</artifactId>
             <version>${scala.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <version>2.10.9</version>
             <scope>provided</scope>
         </dependency>
         <!--SPARK DEPENDENCIES (provided)-->
@@ -103,7 +109,7 @@
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.binary.version}</artifactId>
-            <version>2.2.6</version>
+            <version>3.2.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/scala/org/lamastex/spark/trendcalculus/ForeignExchangeTest.scala
+++ b/src/test/scala/org/lamastex/spark/trendcalculus/ForeignExchangeTest.scala
@@ -1,6 +1,7 @@
 package org.lamastex.spark.trendcalculus
 
-import org.scalatest.Matchers
+import org.scalatest._
+import matchers.should._
 
 import scala.io.Source
 

--- a/src/test/scala/org/lamastex/spark/trendcalculus/ScalableTest.scala
+++ b/src/test/scala/org/lamastex/spark/trendcalculus/ScalableTest.scala
@@ -1,6 +1,7 @@
 package org.lamastex.spark.trendcalculus
 
-import org.scalatest.Matchers
+import org.scalatest._
+import matchers.should._
 
 class ScalableTest extends SparkSpec with Matchers {
 
@@ -20,9 +21,12 @@ class ScalableTest extends SparkSpec with Matchers {
       .csv(filePathRoot+"brent.csv")
       .filter(year(col("DATE")) >= 2016)
 
+    def stringToTimestampUDF = udf((s: String) => new java.sql.Timestamp(new java.text.SimpleDateFormat("yyyy-MM-dd").parse(s).getTime))
+
     val pointDS = df
       .withColumn("ticker", lit("brent"))
-      .select($"ticker", $"DATE" as "x", $"VALUE" as "y")
+      .withColumn("x", stringToTimestampUDF($"DATE"))
+      .select($"ticker", $"x" , $"VALUE" as "y")
       .as[TickerPoint]
 
     pointDS.show

--- a/src/test/scala/org/lamastex/spark/trendcalculus/SparkSpec.scala
+++ b/src/test/scala/org/lamastex/spark/trendcalculus/SparkSpec.scala
@@ -2,9 +2,9 @@ package org.lamastex.spark.trendcalculus
 
 import org.apache.log4j.{Level, Logger}
 import org.apache.spark.sql.SparkSession
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-trait SparkSpec extends FunSuite {
+trait SparkSpec extends AnyFunSuite {
 
   Logger.getLogger("org").setLevel(Level.OFF)
   Logger.getLogger("akka").setLevel(Level.OFF)

--- a/src/test/scala/org/lamastex/spark/trendcalculus/YFinanceTest.scala
+++ b/src/test/scala/org/lamastex/spark/trendcalculus/YFinanceTest.scala
@@ -1,6 +1,7 @@
 package org.lamastex.spark.trendcalculus
 
-import org.scalatest.Matchers
+import org.scalatest._
+import matchers.should._
 import scala.io.Source
 import org.lamastex.spark.trendcalculus._
 


### PR DESCRIPTION
Updated dependencies in pom.xml:

- Scala 2.11.12 -> 2.12.8
- Spark 2.4.4 -> 3.0.1
- scalatest 2.2.6 -> 3.2.2
- Added joda-time 2.10.9

Source code is not changed, tests have been (slightly) refactored to work with new version of scalatest and some work was done on converting strings to java.sql.Date and java.sql.Timestamp.

Tests run without failure and output is the same as previous version.