### PR TITLE
Fixed heap error in tests.

### DIFF
--- a/src/test/scala/org/lamastex/spark/trendcalculus/SparkSpec.scala
+++ b/src/test/scala/org/lamastex/spark/trendcalculus/SparkSpec.scala
@@ -18,6 +18,7 @@ trait SparkSpec extends AnyFunSuite {
         .appName(name)
         .master("local")
         .config("spark.default.parallelism", "1")
+        .config("spark.testing.memory", "500000000")
         .getOrCreate()
 
       try {


### PR DESCRIPTION
 Fixed the bug with the tests that resulted in the following error:
java.lang.IllegalArgumentException: System memory 464519168 must be at least 471859200. Please increase heap size using the --driver-memory option or spark.driver.memory in Spark configuration.
at org.apache.spark.memory.UnifiedMemoryManager$.getMaxMemory(UnifiedMemoryManager.scala:217)
at org.apache.spark.memory.UnifiedMemoryManager$.apply(UnifiedMemoryManager.scala:199)
at org.apache.spark.SparkEnv$.create(SparkEnv.scala:330)
at org.apache.spark.SparkEnv$.createDriverEnv(SparkEnv.scala:175)
at org.apache.spark.SparkContext.createSparkEnv(SparkContext.scala:257)
at org.apache.spark.SparkContext.(SparkContext.scala:424)
at org.apache.spark.SparkContext$.getOrCreate(SparkContext.scala:2520)
at org.apache.spark.sql.SparkSession$Builder$$anonfun$7.apply(SparkSession.scala:935)
at org.apache.spark.sql.SparkSession$Builder$$anonfun$7.apply(SparkSession.scala:926)
at scala.Option.getOrElse(Option.scala:121)