### PR TITLE
Trend Calculus 3.0: One pass reversals

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.lamastex.spark</groupId>
     <artifactId>TrendCalculus-2020</artifactId>
     <packaging>jar</packaging>
-    <version>2.0-SNAPSHOT</version>
+    <version>3.0-SNAPSHOT</version>
   <url>https://github.com/lamastex/spark-trend-calculus</url>
   <description>Trend Calculus in Spark</description>
   <inceptionYear>2017</inceptionYear>

--- a/src/main/scala/org/lamastex/spark/trendcalculus/TrendCalculus2.scala
+++ b/src/main/scala/org/lamastex/spark/trendcalculus/TrendCalculus2.scala
@@ -136,6 +136,7 @@ class TrendCalculus2(timeseries: Dataset[TickerPoint], windowSize: Int, spark: S
       }
 
       reversalStates = reversalStates :+ resPair._1
+      // reversals have the right order
       reversalSeq = resPair._2.map(rev => rev.copy(reversal = rev.reversal * (i + 1))).sortBy(_.tickerPoint.x.getTime)
       allReversals = allReversals ++ reversalSeq
       i += 1

--- a/src/main/scala/org/lamastex/spark/trendcalculus/TrendCalculus2.scala
+++ b/src/main/scala/org/lamastex/spark/trendcalculus/TrendCalculus2.scala
@@ -79,7 +79,7 @@ class TrendCalculus2(timeseries: Dataset[TickerPoint], windowSize: Int, spark: S
     }
   }
 
-  def processBuffer(oldState: TrendCalculus2.State, values: Seq[TickerPoint]): (TrendCalculus2.State, Seq[Reversal]) = {
+  private def processBuffer(oldState: TrendCalculus2.State, values: Seq[TickerPoint]): (TrendCalculus2.State, Seq[Reversal]) = {
     
     val buffer: Seq[TickerPoint] = (oldState.buffer ++ values).sortBy(_.x.getTime) // merging buffered points and new input points and sorting to get right order
     val toFHLS = buffer.dropRight(buffer.length % windowSize) // need multiple of windowsize to make fhls of size windowsize

--- a/src/main/scala/org/lamastex/spark/trendcalculus/TrendCalculus2.scala
+++ b/src/main/scala/org/lamastex/spark/trendcalculus/TrendCalculus2.scala
@@ -134,7 +134,7 @@ class TrendCalculus2(timeseries: Dataset[TickerPoint], windowSize: Int, spark: S
           lastFHLS = if (initZero) emptyFHLS else makeFHLS(Seq(reversalSeq.map(_.tickerPoint).head))
         )
 
-        processBuffer(initialState, if (initZero) reversalSeq.map(_.tickerPoint).tail else reversalSeq.map(_.tickerPoint))
+        processBuffer(initialState, if (!initZero) reversalSeq.map(_.tickerPoint).tail else reversalSeq.map(_.tickerPoint))
       }
 
       reversalStates = reversalStates :+ resPair._1

--- a/src/main/scala/org/lamastex/spark/trendcalculus/TrendCalculus2.scala
+++ b/src/main/scala/org/lamastex/spark/trendcalculus/TrendCalculus2.scala
@@ -18,8 +18,6 @@ import org.apache.spark.sql._
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.streaming.{GroupState, GroupStateTimeout, OutputMode, Trigger}
 import java.sql.Timestamp
-import org.sparkproject.jetty.util.DateCache.Tick
-import avro.shaded.com.google.common.base.Ticker
 
 class TrendCalculus2(timeseries: Dataset[TickerPoint], windowSize: Int, spark: SparkSession, initZero: Boolean = true) extends Serializable {
 

--- a/src/test/scala/org/lamastex/spark/trendcalculus/ScalableTest.scala
+++ b/src/test/scala/org/lamastex/spark/trendcalculus/ScalableTest.scala
@@ -47,8 +47,6 @@ class ScalableTest extends SparkSpec with Matchers {
     reversalTS.orderBy($"tickerPoint.x").show(false)
     reversalTS2.orderBy($"tickerPoint.x").show(false)
 
-    // val nReversalTSs = tc.nReversalsJoinedWithMaxRev(n)
-    // nReversalTSs.show(false)
   }
 
   // Test that stream also works

--- a/src/test/scala/org/lamastex/spark/trendcalculus/ScalableTest.scala
+++ b/src/test/scala/org/lamastex/spark/trendcalculus/ScalableTest.scala
@@ -29,6 +29,10 @@ class ScalableTest extends SparkSpec with Matchers {
       .withColumn("x", stringToTimestampUDF($"DATE"))
       .select($"ticker", $"x" , $"VALUE" as "y")
       .as[TickerPoint]
+      .rdd
+      .repartition(1000)
+      .toDS
+      .orderBy($"x")
 
     pointDS.show
 
@@ -48,7 +52,7 @@ class ScalableTest extends SparkSpec with Matchers {
   }
 
   // Test that stream also works
-  /* sparkTest("Streamable Trend Calculus") { spark =>
+  sparkTest("Streamable Trend Calculus") { spark =>
 
     import org.apache.spark.sql.types._
     import org.apache.spark.sql.functions._
@@ -83,9 +87,9 @@ class ScalableTest extends SparkSpec with Matchers {
     }
 
     val testStream = new TrendCalculus2(pointDS, windowSize, spark)
-      .nReversals(n)
-      .last
+      .reversals
       .writeStream
+      .outputMode("append")
       .format("parquet")
       .option("path", parquetPath)
       .option("checkpointLocation", checkpointPath)
@@ -96,9 +100,9 @@ class ScalableTest extends SparkSpec with Matchers {
     val tickerSchema = new StructType().add("ticker", "string").add("x", "timestamp").add("y", "double")
     val reversalSchema = new StructType().add("tickerPoint", tickerSchema).add("reversal", "int")
 
-    spark.read.schema(reversalSchema).parquet(parquetPath).show(false)
+    spark.read.schema(reversalSchema).parquet(parquetPath).orderBy($"tickerPoint.x").show(false)
     "src/test/scala/org/lamastex/spark/trendcalculus/cleanTmp.sh" !!
-  }*/
+  }
 }
  
 

--- a/src/test/scala/org/lamastex/spark/trendcalculus/ScalableTest.scala
+++ b/src/test/scala/org/lamastex/spark/trendcalculus/ScalableTest.scala
@@ -79,13 +79,6 @@ class ScalableTest extends SparkSpec with Matchers {
     val parquetPath = "src/test/tmp/parquet"
     val checkpointPath = "src/test/tmp/parquet"
 
-    try {
-      new TrendCalculus2(pointDS, windowSize, spark).nReversalsJoined(n)
-      fail()
-    } catch {
-      case _: IllegalArgumentException => {}
-    }
-
     val testStream = new TrendCalculus2(pointDS, windowSize, spark)
       .reversals
       .writeStream

--- a/src/test/scala/org/lamastex/spark/trendcalculus/ScalableTest.scala
+++ b/src/test/scala/org/lamastex/spark/trendcalculus/ScalableTest.scala
@@ -40,15 +40,15 @@ class ScalableTest extends SparkSpec with Matchers {
 
     val reversalTS = tc.reversals
     val reversalTS2 = tc2.reversals
-    reversalTS.show(false)
-    reversalTS2.show(false)
+    reversalTS.orderBy($"tickerPoint.x").show(false)
+    reversalTS2.orderBy($"tickerPoint.x").show(false)
 
-    val nReversalTSs = tc.nReversalsJoinedWithMaxRev(n)
-    nReversalTSs.show(false)
+    // val nReversalTSs = tc.nReversalsJoinedWithMaxRev(n)
+    // nReversalTSs.show(false)
   }
 
   // Test that stream also works
-  sparkTest("Streamable Trend Calculus") { spark =>
+  /* sparkTest("Streamable Trend Calculus") { spark =>
 
     import org.apache.spark.sql.types._
     import org.apache.spark.sql.functions._
@@ -98,6 +98,7 @@ class ScalableTest extends SparkSpec with Matchers {
 
     spark.read.schema(reversalSchema).parquet(parquetPath).show(false)
     "src/test/scala/org/lamastex/spark/trendcalculus/cleanTmp.sh" !!
-  }
+  }*/
 }
+ 
 


### PR DESCRIPTION
### Summary
Refactored the aggregation function to compute the reversals of all orders in one pass.

This removes the need for iterated joins, which speeds up the algorithm considerably.

### Version update
Due to the refactoring, several breaking changes are introduced. For this reason, the version is changed to `3.0`.

### Breaking changes
Due to the change in output format, the following methods are removed:
- `nReversals`
- `nReversalsJoined`
- `nReversalsJoinedWithMaxRev`

The same case classes are used for input and output formats, but the output format is used differently.
`reversal` is now a signed integer (same type as before) where the sign shows the type of reversal (-1 is down, 1 is up, 0 is no reversal), while the magnitude shows the reversal order. For example, a reversal from up to down trend of order 4 is represented as -4.

The `reversals` method works on both static and streaming datasets. When using streaming datasets, the same `TickerPoint` can occur multiple times in the output with increasing reversal order. This is unavoidable since it is generally not known until much later that a point is a high order reversal. On static datasets, the `reversals` method performs an aggregation to only retain the highest order reversal at each point.