### PR TITLE
Revert "Bump scala.version from 2.12.14 to 2.13.8"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,9 +66,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <scala.version>2.13.8</scala.version>
-        <scala.binary.version>2.13</scala.binary.version>
-        <spark.version>3.2.1</spark.version>
+        <scala.version>2.12.14</scala.version>
+        <scala.binary.version>2.12</scala.binary.version>
+        <spark.version>3.0.1</spark.version>
         <java.version>1.8</java.version>
     </properties>
 

--- a/src/main/scala/org/lamastex/spark/trendcalculus/DateUtils.scala
+++ b/src/main/scala/org/lamastex/spark/trendcalculus/DateUtils.scala
@@ -44,7 +44,7 @@ object DateUtils {
   def indices(fq: Frequency.Value, fromTime: Long, toTime: Long): List[Long] = {
     var from = new DateTime(DateUtils.roundTime(fq, fromTime))
     val to = new DateTime(DateUtils.roundTime(fq, toTime))
-    val indices = collection.mutable.ArrayDeque[Long]()
+    val indices = collection.mutable.MutableList[Long]()
     while (from.isBefore(to)) {
       indices += from.toDate.getTime
       from = fq match {

--- a/src/main/scala/org/lamastex/spark/trendcalculus/SeriesUtils.scala
+++ b/src/main/scala/org/lamastex/spark/trendcalculus/SeriesUtils.scala
@@ -3,7 +3,7 @@ package org.lamastex.spark.trendcalculus
 object SeriesUtils {
 
   def movingAverage(timeseries: Array[Point], grouping: Frequency.Value): Unit = {
-    timeseries.groupBy(p => DateUtils.roundTime(grouping, p.x)).flatMap[Point]({ case (group, groupedSeries) =>
+    timeseries.groupBy(p => DateUtils.roundTime(grouping, p.x)).flatMap({ case (group, groupedSeries) =>
       val avg = groupedSeries.map(_.y).sum / groupedSeries.length
       groupedSeries.map(p => {
         Point(p.x, avg)


### PR DESCRIPTION
Reverts lamastex/spark-trend-calculus#

Databricks runtime does not support Scala 2.13